### PR TITLE
Exclude tests from distributed packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.7",
     ],
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=["boto3>=1.11.8", "s2sphere>=0.2.5"],
 )


### PR DESCRIPTION
After installing dynamodb-geo.py in one of my repos, the tests in my repo fail because I also use "tests" as a directory/package name for my tests. 

I get the following: `ModuleNotFoundError: No module named 'tests_my_test_subdir'`. When I use VSCode's "Go To Declaration" to see what the "tests" module points to, it brings me to `./venv/lib/python3.11/site-packages/tests/__init__.py` which has the following content:

```
import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))

import dynamodbgeo
```

When I run `pip uninstall dynamodbgeo` I get the following (notice the "tests" package):

```
% pip uninstall dynamodbgeo
Found existing installation: dynamodbgeo 0.0.3
Uninstalling dynamodbgeo-0.0.3:
  Would remove:
    /Users/amclaughlin/code/my-rep/venv/lib/python3.11/site-packages/dynamodbgeo-0.0.3.dist-info/*
    /Users/amclaughlin/code/my-repo/venv/lib/python3.11/site-packages/dynamodbgeo/*
    /Users/amclaughlin/code/my-repo/venv/lib/python3.11/site-packages/tests/*
Proceed (Y/n)? Y
  Successfully uninstalled dynamodbgeo-0.0.3
```

By replacing `dynamodbgeo` in my requirements.txt file with `dynamodbgeo @ git+ssh://git@github.com/andy-hdai/dynamodb-geo.py@1c8f923` (this branch/commit), it successfully runs the tests.